### PR TITLE
Ndryshim5: Shtim swagger dhe perditesim i disa entiteve

### DIFF
--- a/ManageSuccess-backend/pom.xml
+++ b/ManageSuccess-backend/pom.xml
@@ -38,6 +38,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.6.0</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/entity/TeamMembers.java
+++ b/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/entity/TeamMembers.java
@@ -1,24 +1,18 @@
 package com.managesuccess_backend.ManageSuccess_backend.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class TeamMembers {
 
     @EmbeddedId
     private TeamMembersKey id;
-
-    @ManyToOne
-    @MapsId("userId")
-    @JoinColumn(name = "userId")
-    private Users user;
-
-    @ManyToOne
-    @MapsId("teamId")
-    @JoinColumn(name = "teamId")
-    private Teams team;
 
 }
 

--- a/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/entity/TeamMembersKey.java
+++ b/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/entity/TeamMembersKey.java
@@ -3,12 +3,14 @@ package com.managesuccess_backend.ManageSuccess_backend.entity;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
 @Embeddable
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class TeamMembersKey implements Serializable {
 
     private String userId;

--- a/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/entity/UserExperiences.java
+++ b/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/entity/UserExperiences.java
@@ -2,10 +2,14 @@ package com.managesuccess_backend.ManageSuccess_backend.entity;
 
 import com.managesuccess_backend.ManageSuccess_backend.enums.ExperienceLevel;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class UserExperiences {
 
     @EmbeddedId
@@ -13,16 +17,6 @@ public class UserExperiences {
 
     @Enumerated(EnumType.STRING)
     private ExperienceLevel experienceLevel;
-
-    @ManyToOne
-    @MapsId("userId")
-    @JoinColumn(name = "userId")
-    private Users user;
-
-    @ManyToOne
-    @MapsId("userExperiencesOptionsId")
-    @JoinColumn(name = "userExperiencesOptionsId")
-    private UserExperiencesOptions userExperiencesOptions;
 
 }
 

--- a/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/entity/UserExperiencesKey.java
+++ b/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/entity/UserExperiencesKey.java
@@ -3,12 +3,14 @@ package com.managesuccess_backend.ManageSuccess_backend.entity;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
 @Embeddable
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class UserExperiencesKey implements Serializable {
 
     private String userId;

--- a/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/entity/Users.java
+++ b/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/entity/Users.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 public class Users {
 
     @Id
+    @GeneratedValue(generator = "custom_id")
     @GenericGenerator(
             name = "custom_id",
             type = CustomIdWithPrefixGenerator.class,

--- a/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/services/TeamMembersService.java
+++ b/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/services/TeamMembersService.java
@@ -34,10 +34,9 @@ public class TeamMembersService {
     public TeamMembers updateTeamMember(String userId, String teamId, TeamMembers updatedTeamMember) {
         Optional<TeamMembers> existingTeamMember = teamMembersRepository.findById(new TeamMembersKey(userId, teamId));
         if (existingTeamMember.isPresent()) {
-            TeamMembers teamMemberToUpdate = existingTeamMember.get();
-            teamMemberToUpdate.setUser(updatedTeamMember.getUser());
-            teamMemberToUpdate.setTeam(updatedTeamMember.getTeam());
-            return teamMembersRepository.save(teamMemberToUpdate);
+            existingTeamMember.get().getId().setTeamId(teamId);
+            existingTeamMember.get().getId().setTeamId(userId);
+            return teamMembersRepository.save(existingTeamMember.get());
         }
         return null; // TeamMember not found
     }

--- a/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/services/UserExperiencesService.java
+++ b/ManageSuccess-backend/src/main/java/com/managesuccess_backend/ManageSuccess_backend/services/UserExperiencesService.java
@@ -7,7 +7,6 @@ import com.managesuccess_backend.ManageSuccess_backend.entity.UserExperiencesKey
 import com.managesuccess_backend.ManageSuccess_backend.enums.ExperienceLevel;
 import com.managesuccess_backend.ManageSuccess_backend.repositories.UserExperiencesRepository;
 import com.managesuccess_backend.ManageSuccess_backend.utils.Utilities;
-import org.apache.catalina.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import java.util.*;
@@ -35,7 +34,7 @@ public class UserExperiencesService {
     public List<UserExperiences> getUserExperiencesByUserIdOrByExperienceId(String user, String experience){
         if(!Utilities.isNullOrEmpty(user)) return userExperiencesRepository.findByUserId(user);
         else if (!Utilities.isNullOrEmpty(experience)) return userExperiencesRepository.findByExperienceId(experience);
-        return null;
+        return this.getAllUsersExperiences();
     }
 
     // Update an userExperience
@@ -59,4 +58,7 @@ public class UserExperiencesService {
         return false;
     }
 
+    public List<UserExperiences> getAllUsersExperiences() {
+        return userExperiencesRepository.findAll();
+    }
 }


### PR DESCRIPTION
**Ndryshim5:** Shtim swagger dhe perditesim i disa entiteve

- Shtohet swagger per te gjeneruar dokumentacion me lehte dhe per te bere testimet me shpejte. 
- Ndryshohen disa entitete qe kishin kolona extra. 
- Jane perdor composite primary keys dhe nuk ka nevoje qe te kene foreign keys.